### PR TITLE
Install script (suggestion)

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,40 @@
+[metadata]
+name = conala-baseline
+version = 1.1.0
+description = CoNaLa Preprocessing Scripts/Baseline
+author = Graham Neubig, Edgar Chen
+long-description = file: README.md
+long-description-content-type = text/markdown; charset=UTF-8
+url = https://github.com/conala-corpus/conala-baseline
+project-urls =
+    Documentation = https://conala-corpus.github.io/
+license = Apache Software License
+classifiers =
+    License :: OSI Approved :: Apache Software License
+    Programming Language :: Python
+
+[options]
+zip_safe = False
+py_modules =
+    bleu_score
+    conala_eval
+
+include_package_data = True
+package_dir =
+    =eval
+python_requires = >=3.5.0
+install_requires =
+
+[options.entry_points]
+console_scripts =
+    conala-eval = conala_eval:main
+
+[aliases]
+dists = bdist_wheel
+
+[bdist_wheel]
+universal = 1
+
+[devpi:upload]
+no-vcs = 1
+formats = bdist_wheel

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,12 @@
+import sys
+
+from pkg_resources import VersionConflict, require
+from setuptools import setup
+
+try:
+    require('setuptools>=38.3')
+except VersionConflict:
+    print("Error: version of setuptools is too old (<38.3)!")
+    sys.exit(1)
+
+setup()


### PR DESCRIPTION
Hello,

it would be useful to have an installable version of the evaluation scripts for external users.

I made an example install script that allows for installing the bleu_score and conala_eval modules into a Python environment (directly or by creating a wheel).

I had to explicitly list the two modules using py_modules in the setup.cfg and they will be installed into the site_packages root as there is no package structure (due to no __init__.py files being present). For the same reason I did not include the preproc scripts (which have a distinct set of dependencies anyway). It might be a good idea to use a base package, but to my knowledge that would require changing the project structure a little.

Also, I wasn't sure about the authors list in setup.cfg. I took the commit history as a reference, but if anybody else was involved in writing this code, they should be added as well.